### PR TITLE
Fixes #11 (File id used as user profile id)

### DIFF
--- a/classes/output/allbackups_table.php
+++ b/classes/output/allbackups_table.php
@@ -39,6 +39,8 @@ require_once($CFG->libdir . '/tablelib.php');
  */
 class allbackups_table extends \table_sql {
 
+    public $useridfield = 'userid';
+
     /**
      * Constructor
      * @param int $uniqueid all tables have to have a unique id, this is used


### PR DESCRIPTION
This would fix #11 .

Analog implementation in Moodle core: https://github.com/moodle/moodle/blob/338b60f43b25c84e684dc075ff59132a24461d32/mod/quiz/report/attemptsreport_table.php#L38

Checked locally, it uses the correct field then to generate the profile URL.