### PR TITLE
Add pagination and improve download handling

### DIFF
--- a/classes/output/autobackups_table.php
+++ b/classes/output/autobackups_table.php
@@ -51,9 +51,8 @@ class autobackups_table extends \flexible_table {
         $url->param('tab', 'autobackup');
         $this->define_baseurl($url);
         $this->pageable(true);
+
         if (!optional_param('downloadallselectedfiles', 0, PARAM_ALPHA)) {
-            // Set Download flag so we can check it before defining columns/headers to show.
-            // Don't set if downloading files.
             $this->is_downloading(optional_param('download', '', PARAM_ALPHA), 'allbackups');
         }
 
@@ -63,7 +62,6 @@ class autobackups_table extends \flexible_table {
 
         // Add selector column if not downloading report.
         if (!$this->is_downloading()) {
-            // Add selector column to report.
             $columns[] = 'selector';
 
             $options = [
@@ -96,9 +94,10 @@ class autobackups_table extends \flexible_table {
      * Helper function to add data to table.
      * Implements custom sort/pagination as we don't use sql to build this table.
      *
+     * @param \user_filtering $ufiltering
      * @throws \dml_exception
      */
-    public function adddata() {
+    public function adddata($ufiltering) {
         global $SESSION;
 
         $rows = array();
@@ -181,14 +180,13 @@ class autobackups_table extends \flexible_table {
             $output .= ' | '. html_writer::link($deleteurl, get_string('delete'));
         }
         return $output;
-
     }
 
     /**
      * Display size row.
      *
      * @param \stdClass $row
-     * @return \lang_string|string
+     * @return string
      */
     public function col_size($row) {
         return display_size($row->size);
@@ -207,7 +205,7 @@ class autobackups_table extends \flexible_table {
     /**
      * Function to display the checkbox for bulk actions.
      *
-     * @param \stdClass $row the data from the db containing all fields from the current row.
+     * @param \stdClass $row
      * @return string
      */
     public function col_selector($row) {
@@ -224,12 +222,11 @@ class autobackups_table extends \flexible_table {
         return $OUTPUT->render($itemcheckbox);
     }
 
-
     /**
      * Function to filter results using the filename.
      *
      * @param string $filename
-     * @return bool|int
+     * @return bool
      */
     private function filter_filename($filename) {
         global $SESSION;
@@ -238,6 +235,9 @@ class autobackups_table extends \flexible_table {
         if (!empty($SESSION->user_filtering['filename'])) {
             foreach ($SESSION->user_filtering['filename'] as $filter) {
                 $found = $this->filter_filename_helper($filter['operator'], $filter['value'], $filename);
+                if (!$found) {
+                    break;
+                }
             }
         }
         return $found;
@@ -252,7 +252,6 @@ class autobackups_table extends \flexible_table {
      * @return false|int
      */
     private function filter_filename_helper($operator, $value, $filename) {
-        // Filter rows based on any filters set.
         switch ($operator) {
             case 0: // Contains.
                 $regex = "/" . $value . "/";
@@ -272,6 +271,8 @@ class autobackups_table extends \flexible_table {
             case 5: // Empty.
                 $regex = "/^$/";
                 break;
+            default:
+                $regex = "/.*/";
         }
         return preg_match($regex, $filename);
     }
@@ -288,6 +289,9 @@ class autobackups_table extends \flexible_table {
         if (!empty($SESSION->user_filtering['timecreated'])) {
             foreach ($SESSION->user_filtering['timecreated'] as $filter) {
                 $found = $this->filter_timemodified_helper($filter['before'], $filter['after'], $timemodified);
+                if (!$found) {
+                    break;
+                }
             }
         }
 
@@ -304,7 +308,7 @@ class autobackups_table extends \flexible_table {
      */
     private function filter_timemodified_helper($before, $after, $timemodified) {
         $found = true;
-        if (!empty($before)) { // Only if the before value is not empty.
+        if (!empty($before)) {
             if ($before < $timemodified) {
                 $found = false;
             }
@@ -315,5 +319,18 @@ class autobackups_table extends \flexible_table {
             }
         }
         return $found;
+    }
+
+    /**
+     * Sets the number of rows to display per page.
+     *
+     * @param int $perpage Number of rows to display per page
+     * @param int $maxrows Maximum number of rows allowed, defaults to 5000
+     */
+    public function pagesize($perpage, $maxrows = 5000) {
+        // Redefine to force the pagination that flexible_table handles.
+        parent::pagesize($perpage, $maxrows);
+        // Call setup again in case configuration needs to be refreshed.
+        parent::setup();
     }
 }

--- a/index.php
+++ b/index.php
@@ -21,11 +21,12 @@
  * @copyright  2020 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-use ZipStream\Option\Archive;
-use ZipStream\ZipStream;
 
 require_once('../../config.php');
 require_once($CFG->libdir . '/adminlib.php');
+require_once($CFG->dirroot.'/report/allbackups/lib.php'); // For using report_allbackups_download_zip().
+
+global $DB;
 
 $delete = optional_param('delete', '', PARAM_TEXT);
 $filename = optional_param('filename', '', PARAM_TEXT);
@@ -33,6 +34,9 @@ $deleteselected = optional_param('deleteselectedfiles', '', PARAM_TEXT);
 $downloadselected = optional_param('downloadallselectedfiles', '', PARAM_TEXT);
 $fileids = optional_param('fileids', '', PARAM_TEXT);
 $currenttab = optional_param('tab', 'core', PARAM_TEXT);
+
+// Records per page, 0 = "show all".
+$perpage = optional_param('perpage', 20, PARAM_INT);
 
 admin_externalpage_setup('reportallbackups', '', array('tab' => $currenttab), '', array('pagelayout' => 'report'));
 
@@ -42,6 +46,27 @@ if (empty($backupdest) && $currenttab == 'autobackup') {
 }
 
 $context = context_system::instance();
+
+// Calculate total backups in "Standard" (DB).
+$sql = "SELECT COUNT(*)
+          FROM {files} f
+         WHERE f.filename LIKE '%.mbz'
+           AND f.component <> 'tool_recyclebin'
+           AND f.filearea <> 'draft'";
+$standardcount = $DB->count_records_sql($sql);
+
+// Calculate total backups in "Automated" (folder).
+$autobackupcount = 0;
+if (!empty($backupdest) && is_dir($backupdest)) {
+    $directory = new RecursiveDirectoryIterator($backupdest);
+    $iterator = new RecursiveIteratorIterator($directory);
+    foreach ($iterator as $file) {
+        if ($file->isFile() && $file->getExtension() === 'mbz') {
+            $autobackupcount++;
+        }
+    }
+}
+
 if (has_capability('report/allbackups:delete', $context)) {
 
     if (!empty($deleteselected) || !empty($delete)) { // Delete action.
@@ -102,20 +127,22 @@ if (has_capability('report/allbackups:delete', $context)) {
                 } else {
                     $fs = new file_storage();
                     $file = $fs->get_file_by_id((int)$id);
-                    $fileext = pathinfo($file->get_filename(), PATHINFO_EXTENSION);
-                    // Make sure the file exists, and it is a backup file we are deleting.
-                    if (!empty($file) && $fileext == 'mbz') {
-                        $file->delete();
-                        $event = \report_allbackups\event\backup_deleted::create(array(
-                            'context' => context::instance_by_id($file->get_contextid()),
-                            'objectid' => $file->get_id(),
-                            'other' => array('filename' => $file->get_filename())));
-                        $event->trigger();
-                        $count++;
+                    if (!empty($file)) {
+                        $fileext = pathinfo($file->get_filename(), PATHINFO_EXTENSION);
+                        if ($fileext == 'mbz') {
+                            $file->delete();
+                            $event = \report_allbackups\event\backup_deleted::create(array(
+                                'context' => context::instance_by_id($file->get_contextid()),
+                                'objectid' => $file->get_id(),
+                                'other' => array('filename' => $file->get_filename())));
+                            $event->trigger();
+                            $count++;
+                        } else {
+                            \core\notification::add(get_string('couldnotdeletefile', 'report_allbackups', $id));
+                        }
                     } else {
                         \core\notification::add(get_string('couldnotdeletefile', 'report_allbackups', $id));
                     }
-
                 }
             }
             \core\notification::add(get_string('filesdeleted', 'report_allbackups', $count), \core\notification::SUCCESS);
@@ -123,80 +150,83 @@ if (has_capability('report/allbackups:delete', $context)) {
     }
 }
 
-// Triggers when "Download all select files" is clicked.
+// Handle download selected files.
 if (!empty($downloadselected) && confirm_sesskey()) {
     if (empty($fileids)) {
-
-        $fileids = array();
-        // Raise memory limit - each file is loaded in PHP memory, so this much be larger than the largest backup file.
+        $filepaths = array();
         raise_memory_limit(MEMORY_HUGE);
 
-        // Initialize zip for saving multiple selected files at once.
-        $options = new Archive();
-        $options->setSendHttpHeaders(true);
-        $zip = new ZipStream('all_backups.zip', $options);
-
-        // Get list of ids from the checked checkboxes.
         $post = data_submitted();
 
         if ($currenttab == 'autobackup') {
-            // Get list of names from the checked backups.
             foreach ($post as $k => $v) {
                 if (preg_match('/^item(.*)/', $k, $m)) {
-                    $fileids[] = $v; // Use value (filename) in array.
-                }
-            }
-
-            // Check nothing weird passed in filename - protect against directory traversal etc.
-            // Check to make sure this is an mbz file.
-            foreach ($fileids as $filename) {
-
-                if ($filename == clean_param($filename, PARAM_FILE) &&
-                    pathinfo($filename, PATHINFO_EXTENSION) == 'mbz' &&
-                    is_readable($backupdest .'/'. $filename)) {
-
-                        $file = $backupdest.'/'.$filename;
-                        $filecontents = file_get_contents($file, FILE_USE_INCLUDE_PATH);
-                        $zip->addFile($filename, $filecontents);
-                } else {
-                    \core\notification::add(get_string('couldnotdownloadfile', 'report_allbackups'));
+                    $filenamevalue = clean_param($v, PARAM_FILE);
+                    if ($filenamevalue &&
+                        pathinfo($filenamevalue, PATHINFO_EXTENSION) == 'mbz' &&
+                        is_readable($backupdest . '/' . $filenamevalue)) {
+                        $filepaths[] = [
+                            'filepath' => $backupdest . '/' . $filenamevalue,
+                            'filename' => $filenamevalue
+                        ];
+                    } else {
+                        \core\notification::add(get_string('couldnotdownloadfile', 'report_allbackups'));
+                    }
                 }
             }
         } else {
-            // Get list of ids from the checked backups.
+            $fs = new file_storage();
             foreach ($post as $k => $v) {
                 if (preg_match('/^item(\d+)$/', $k, $m)) {
-                    $fileids[] = $m[1];
-                }
-            }
-
-            // Check nothing weird passed in filename - protect against directory traversal etc.
-            // Check to make sure this is an mbz file.
-            foreach ($fileids as $id) {
-
-                // Translate the file id into file name / contents.
-                $fs = new file_storage();
-                $file = $fs->get_file_by_id((int)$id);
-                $fileext = pathinfo($file->get_filename(), PATHINFO_EXTENSION);
-
-                // Make sure the file exists, and it is a backup file we are downloading.
-                if (!empty($file) && $fileext == 'mbz') {
-                    $zip->addFile($file->get_filename(), $file->get_content());
-                } else {
-                    \core\notification::add(get_string('couldnotdownloadfile', 'report_allbackups'));
+                    $fileid = (int)$m[1];
+                    $file = $fs->get_file_by_id($fileid);
+                    if ($file) {
+                        $fileext = pathinfo($file->get_filename(), PATHINFO_EXTENSION);
+                        if ($fileext == 'mbz') {
+                            $localtemp = tempnam(sys_get_temp_dir(), 'moodle_backup_');
+                            $file->copy_content_to($localtemp);
+                            $filepaths[] = [
+                                'filepath' => $localtemp,
+                                'filename' => $file->get_filename()
+                            ];
+                        } else {
+                            \core\notification::add(get_string('couldnotdownloadfile', 'report_allbackups'));
+                        }
+                    }
                 }
             }
         }
-        $zip->finish();
-        exit;
+
+        if (!empty($filepaths)) {
+            report_allbackups_download_zip($filepaths);
+        } else {
+            \core\notification::add(get_string('couldnotdownloadfile', 'report_allbackups'));
+            redirect($PAGE->url);
+        }
     }
 }
 
+// Define filters for tables.
 if ($currenttab == 'autobackup') {
     $filters = array('filename' => 0, 'timecreated' => 0);
 } else {
     $filters = array('filename' => 0, 'realname' => 0, 'coursecategory' => 0, 'filearea' => 0, 'timecreated' => 0);
 }
+
+// Setup records per page options.
+$perpageoptions = [
+    10 => 10,
+    20 => 20,
+    50 => 50,
+    100 => 100,
+    200 => 200,
+    500 => 500,
+    0 => get_string('all')
+];
+
+$perpageselect = new single_select($PAGE->url, 'perpage', $perpageoptions, $perpage, null);
+$perpageselect->set_label(get_string('recordsperpage', 'report_allbackups'));
+
 if ($currenttab == 'autobackup') {
     $table = new \report_allbackups\output\autobackups_table('autobackups');
 } else {
@@ -210,24 +240,34 @@ if (!$table->is_downloading()) {
     // Print the page header.
     $PAGE->set_title(get_string('pluginname', 'report_allbackups'));
     echo $OUTPUT->header();
+
     if (!empty(get_config('backup', 'backup_auto_destination'))) {
         $row = $tabs = array();
-        $row[] = new tabobject('core',
+        $row[] = new tabobject(
+            'core',
             $CFG->wwwroot.'/report/allbackups',
-            get_string('standardbackups', 'report_allbackups'));
-        $row[] = new tabobject('autobackup',
+            get_string('standardbackups', 'report_allbackups') . " ({$standardcount})"
+        );
+        $row[] = new tabobject(
+            'autobackup',
             $CFG->wwwroot.'/report/allbackups/index.php?tab=autobackup',
-            get_string('autobackup', 'report_allbackups'));
+            get_string('autobackup', 'report_allbackups') . " ({$autobackupcount})"
+        );
         $tabs[] = $row;
         print_tabs($tabs, $currenttab);
     }
+
     if ($currenttab == 'autobackup') {
         echo $OUTPUT->box(get_string('autobackup_description', 'report_allbackups'));
     } else {
         echo $OUTPUT->box(get_string('plugindescription', 'report_allbackups'));
     }
+
     $ufiltering->display_add();
     $ufiltering->display_active();
+
+    // Display records per page selector.
+    echo html_writer::div($OUTPUT->render($perpageselect), 'perpagecombobox');
 
     echo '<form action="index.php" method="post" id="allbackupsform">';
     echo html_writer::start_div();
@@ -239,8 +279,12 @@ if (!$table->is_downloading()) {
     $event = \report_allbackups\event\report_downloaded::create();
     $event->trigger();
 }
+
+// Adjust pagination.
+$perpageval = ($perpage == 0) ? 999999 : $perpage;
+
 if ($currenttab == 'autobackup') {
-    // Get list of files from backup.
+    $table->pagesize($perpageval, 999999);
     $table->adddata($ufiltering);
 } else {
     list($extrasql, $params) = $ufiltering->get_sql_filter();
@@ -249,31 +293,32 @@ if ($currenttab == 'autobackup') {
 
     $from = '{files} f JOIN {user} u on u.id = f.userid';
     if (strpos($extrasql, 'c.category') !== false) {
-        // Category filter included, Join with course table.
         $from .= ' JOIN {context} cx ON cx.id = f.contextid AND cx.contextlevel = '.CONTEXT_COURSE .
                  ' JOIN {course} c ON c.id = cx.instanceid';
     }
-    $where = "f.filename like '%.mbz' and f.component <> 'tool_recyclebin' and f.filearea <> 'draft'";
+    $where = "f.filename like '%.mbz' AND f.component <> 'tool_recyclebin' AND f.filearea <> 'draft'";
     if (!empty($extrasql)) {
-        $where .= " and ".$extrasql;
+        $where .= " AND ".$extrasql;
     }
 
     $table->set_sql($fields, $from, $where, $params);
-    $table->out(40, true);
+    $table->out($perpageval, true);
 }
 
 if (!$table->is_downloading()) {
-
     echo html_writer::tag('input', "", array('name' => 'deleteselectedfiles', 'type' => 'submit',
         'id' => 'deleteallselected', 'class' => 'btn btn-secondary',
         'value' => get_string('deleteselectedfiles', 'report_allbackups')));
+
     echo html_writer::tag('input', "", array('name' => 'downloadallselectedfiles', 'style' => 'margin: 10px', 'type' => 'submit',
         'id' => 'downloadallselected', 'class' => 'btn btn-secondary',
         'value' => get_string('downloadallselectedfiles', 'report_allbackups')));
 
     echo html_writer::end_div();
     echo html_writer::end_tag('form');
+
     $event = \report_allbackups\event\report_viewed::create();
     $event->trigger();
+
     echo $OUTPUT->footer();
 }

--- a/lang/en/report_allbackups.php
+++ b/lang/en/report_allbackups.php
@@ -48,3 +48,4 @@ $string['plugindescription'] = 'This report shows all *.mbz (Moodle backup files
 $string['pluginname'] = 'All backups';
 $string['privacy:metadata'] = 'The all backups report plugin does not store any personal data';
 $string['standardbackups'] = 'Standard backups';
+$string['recordsperpage'] = 'Records per page';

--- a/lang/es/report_allbackups.php
+++ b/lang/es/report_allbackups.php
@@ -1,0 +1,51 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Plugin strings are defined here.
+ *
+ * @package     report_allbackups
+ * @category    string
+ * @copyright   2020 Catalyst IT
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$string['allbackups:delete'] = 'Eliminar copias de seguridad';
+$string['allbackups:view'] = 'Ver informe de todas las copias de seguridad';
+$string['areyousurebulk'] = '¿Está seguro de que desea eliminar los {$a} archivo(s) seleccionados?';
+$string['autobackup'] = 'Copias de seguridad automáticas almacenadas en el directorio especificado del servidor';
+$string['autobackup_description'] = 'Este informe muestra todos los archivos *.mbz (archivos de copia de seguridad de Moodle) almacenados en el directorio especificado en la configuración de copias de seguridad automáticas.';
+$string['autobackupnotset'] = 'El destino de la copia de seguridad automática no está configurado - no puede usar esta función';
+$string['component'] = 'Componente';
+$string['couldnotdeletefile'] = 'No se pudo encontrar el archivo con id: {$a}';
+$string['couldnotdownloadfile'] = 'No se pueden descargar todos los archivos de copia de seguridad';
+$string['downloadallselectedfiles'] = 'Descargar archivos seleccionados';
+$string['coursecategory'] = 'Categoría del curso';
+$string['deleteselectedfiles'] = 'Eliminar archivos seleccionados';
+$string['eventautobackupdeleted'] = 'Se eliminó un archivo de copia de seguridad automática';
+$string['eventbackupdeleted'] = 'Se eliminó un archivo de copia de seguridad';
+$string['eventreportdownloaded'] = 'Informe de todas las copias de seguridad descargado';
+$string['eventreportviewed'] = 'Informe de todas las copias de seguridad visto';
+$string['filearea'] = 'Área de archivos';
+$string['filename'] = 'Nombre del archivo';
+$string['filesdeleted'] = 'Se eliminaron {$a} archivo(s)';
+$string['plugindescription'] = 'Este informe muestra todos los archivos *.mbz (archivos de copia de seguridad de Moodle) en su sitio, tenga en cuenta que después de eliminar un archivo, Moodle puede tardar hasta 4 días en eliminar el archivo del almacenamiento en disco.';
+$string['pluginname'] = 'Todas las copias de seguridad';
+$string['privacy:metadata'] = 'El plugin de informe de todas las copias de seguridad no almacena ningún dato personal';
+$string['standardbackups'] = 'Copias de seguridad estándar';
+$string['recordsperpage'] = 'Registros por página';

--- a/lib.php
+++ b/lib.php
@@ -79,3 +79,59 @@ function report_allbackups_pluginfile($course,
     }
 }
 
+/**
+ * Creates and sends a ZIP file to the browser using native PHP ZipArchive.
+ *
+ * @param array  $filepaths Array of files to be compressed. Each element must be an associative array with:
+ *                         [
+ *                           'filepath' => '/complete/path/to/file',
+ *                           'filename' => 'nameInsideZIP.mbz'
+ *                         ]
+ * @param string $zipname   (Optional) Base name for the ZIP file to download; if not provided,
+ *                         it will use a timestamp in the name
+ * @throws moodle_exception If ZIP cannot be created or if no files exist
+ */
+function report_allbackups_download_zip(array $filepaths, string $zipname = '') {
+    global $CFG;
+
+    if (empty($filepaths)) {
+        throw new moodle_exception('couldnotdownloadfile', 'report_allbackups');
+    }
+
+    // If no ZIP name provided, generate one with timestamp.
+    if (empty($zipname)) {
+        // Format: YYYYmmdd_HHMM_all_backups.zip
+        $zipname = date('Ymd_Hi') . '_all_backups.zip';
+    }
+
+    // Create a temporary file.
+    $tempzip = tempnam(sys_get_temp_dir(), 'moodle_allbackups_');
+
+    $zip = new ZipArchive();
+    if ($zip->open($tempzip, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+        throw new moodle_exception('couldnotdownloadfile', 'report_allbackups', '', null,
+            'Unable to create temporary ZIP archive.');
+    }
+
+    // Add each file to the ZIP.
+    foreach ($filepaths as $info) {
+        if (!empty($info['filepath']) && !empty($info['filename'])) {
+            $localpath = $info['filepath'];
+            $nameinzip = $info['filename'];
+            if (is_readable($localpath)) {
+                $zip->addFile($localpath, $nameinzip);
+            }
+        }
+    }
+    $zip->close();
+
+    // Send headers to force download.
+    header('Content-Type: application/zip');
+    header('Content-Disposition: attachment; filename="' . $zipname . '"');
+    header('Content-Length: ' . filesize($tempzip));
+    flush();
+
+    readfile($tempzip);
+    @unlink($tempzip);
+    exit;
+}

--- a/version.php
+++ b/version.php
@@ -19,14 +19,14 @@
  *
  * @package     report_allbackups
  * @copyright   2020 Catalyst IT
- * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'report_allbackups';
-$plugin->release = '4.0 (2022031501)';
-$plugin->version = 2022031501;
-$plugin->requires = 2021091100; // Requires 4.0.
-$plugin->maturity = MATURITY_STABLE;
-$plugin->supported = [400, 400];
+$plugin->release   = '4.5 (2025012800)'; // Cambia el número si haces varias versiones el mismo día.
+$plugin->version   = 2025012800;         // YYYYMMDDXX.
+$plugin->requires  = 2021091100;         // Moodle 4.0.
+$plugin->maturity  = MATURITY_STABLE;
+$plugin->supported = [400, 405];         // Compatible con la versión 4.5.


### PR DESCRIPTION
This pull request enhances the report_allbackups plugin with several improvements:

### Changes
* Replace ZipStream with native PHP ZipArchive for file downloads
* Add configurable pagination with records per page selector (10-500)
* Add backup count indicators in navigation tabs
* Add dynamic pagination support for tables
* Add new language strings for pagination
* Update version and compatibility for Moodle 4.5

### Testing Instructions
1. Install/update the plugin
2. Go to Site Administration > Reports > All backups
3. Verify that:
   - You can see the number of backups in each tab
   - The records per page selector works (try different values)
   - You can download multiple selected backups
   - Pagination works correctly in both Standard and Automated backup tabs
   - Language strings display correctly in both English and Spanish

### Dependencies
* No external dependencies (removed ZipStream dependency)

### Documentation
* Added PHPDoc for new methods
* Updated code comments
* Added language strings

### Checklist
- [x] Code follows Moodle coding style
- [x] PHPDoc blocks updated
- [x] Language file strings added
- [x] Version number updated
- [x] Unit tests pass
- [x] Tested with both PostgreSQL and MySQL
- [x] Tested with PHP 7.4 and 8.1