### PR TITLE
ISSUE25: Speed up query with explicit component and filearea checks

### DIFF
--- a/index.php
+++ b/index.php
@@ -280,10 +280,20 @@ if ($currenttab == 'autobackup') {
         $from .= ' JOIN {context} cx ON cx.id = f.contextid AND cx.contextlevel = '.CONTEXT_COURSE .
                  ' JOIN {course} c ON c.id = cx.instanceid';
     }
-    $where = "f.filename like '%.mbz' and f.component <> 'tool_recyclebin' and f.filearea <> 'draft'";
+    $config = get_config('report_allbackups');
+    $components = !empty($config->components) ? $config->components : 'backup,user';
+    $fileareas = !empty($config->fileareas) ? $config->fileareas : 'activity,automated,backup,course,private';
+    $componentslist = explode(',', $components);
+    $fileareaslist = explode(',', $fileareas);
+    [$insqlcomp, $inparamscomp] = $DB->get_in_or_equal($componentslist, SQL_PARAMS_NAMED, 'comp_');
+    [$insqlarea, $inparamsarea] = $DB->get_in_or_equal($fileareaslist, SQL_PARAMS_NAMED, 'filearea_');
+
+    $where = "f.mimetype = 'application/vnd.moodle.backup' AND f.component $insqlcomp AND f.filearea $insqlarea";
     if (!empty($extrasql)) {
         $where .= " and ".$extrasql;
     }
+
+    $params = array_merge($params, $inparamscomp, $inparamsarea);
 
     $table->set_sql($fields, $from, $where, $params);
     $table->out($perpageval, true);

--- a/lang/en/report_allbackups.php
+++ b/lang/en/report_allbackups.php
@@ -32,6 +32,9 @@ $string['autobackup'] = 'Automated backups stored in specified server directory'
 $string['autobackup_description'] = 'This report shows all *.mbz (Moodle backup files) stored in the directory specified in the automated backups settings.';
 $string['autobackupnotset'] = 'Automated backup destination is not set - you cannot use this function';
 $string['component'] = 'Component';
+$string['components'] = 'Components';
+$string['componentshelp'] = 'A comma-separated list of components to include in the report.
+For example, to include only automated backups and user-initiated backups, use: "backup,user". The default will be used if left blank.';
 $string['couldnotdeletefile'] = 'The file with id: {$a} could not be found';
 $string['couldnotdownloadfile'] = 'Unable to download all backup files';
 $string['downloadallselectedfiles'] = 'Download selected files';
@@ -42,6 +45,9 @@ $string['eventbackupdeleted'] = 'A backup file was deleted';
 $string['eventreportdownloaded'] = 'All backups report downloaded';
 $string['eventreportviewed'] = 'All backups report viewed';
 $string['filearea'] = 'File area';
+$string['fileareas'] = 'File areas';
+$string['fileareashelp'] = 'A comma-separated list of file areas to include in the report.
+For example, to include only activity and course backups, use: "activity,course". The default will be used if left blank.';
 $string['filename'] = 'File name';
 $string['filesdeleted'] = '{$a} file(s) were deleted';
 $string['plugindescription'] = 'This report shows all *.mbz (Moodle backup files) on your site, please note that after deleting a file, Moodle can take up to 4 days before removing the file from disk storage.';

--- a/settings.php
+++ b/settings.php
@@ -25,8 +25,31 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$ADMIN->add('reports', new admin_externalpage('reportallbackups', get_string('pluginname', 'report_allbackups'),
-    "$CFG->wwwroot/report/allbackups/index.php", 'report/allbackups:view'));
+$ADMIN->add(
+    'reports',
+    new admin_externalpage(
+        'reportallbackups',
+        get_string('pluginname', 'report_allbackups'),
+        "$CFG->wwwroot/report/allbackups/index.php",
+        'report/allbackups:view'
+    )
+);
 
-// No report settings.
-$settings = null;
+$settings = new admin_settingpage('report_allbackups_settings', new lang_string('pluginname', 'report_allbackups'));
+
+if ($ADMIN->fulltree) {
+    $settings->add(new admin_setting_configtext(
+        'report_allbackups/components',
+        new lang_string('components', 'report_allbackups'),
+        new lang_string('componentshelp', 'report_allbackups'),
+        'backup,user',
+        PARAM_TAGLIST
+    ));
+    $settings->add(new admin_setting_configtext(
+        'report_allbackups/fileareas',
+        new lang_string('fileareas', 'report_allbackups'),
+        new lang_string('fileareashelp', 'report_allbackups'),
+        'activity,automated,backup,course,private',
+        PARAM_TAGLIST
+    ));
+}


### PR DESCRIPTION
For Issue #25 

I've added components and filearea as configurable items as this is now making those values explicit. We're using block_sharing_cart, for example, so we would want to include that in our configuration.

I've also used an explicit mimetype rather than a LIKE on the filename as I think equals is faster than LIKE.

Doing some checks using EXPLAIN (in MySQL), if you wanted to, we could still use the `f.component' <> 'tool_recyclebin'` alongside `f.component IN ('backup', 'user')` and (and the same for filearea) not cause any performance issue.

Let me know how you'd like to proceed, and I'll update as necessary.